### PR TITLE
Fix/logging

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -65,6 +65,18 @@
   			<version>2.3.0</version>
 		</dependency>
 		
+		<dependency>
+    		<groupId>io.sentry</groupId>
+    		<artifactId>sentry-spring-boot-starter</artifactId>
+    		<version>4.0.0</version>
+		</dependency>
+		
+		<dependency>
+    		<groupId>io.sentry</groupId>
+    		<artifactId>sentry-logback</artifactId>
+    		<version>4.0.0</version>
+		</dependency>
+		
 	</dependencies>
 
 	<build>

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Either just run this script without any input argument to start the application.
+# Or provide the argument DEBUG or TRACE to select one of the two logging levels.
+
+if [ $# -eq 0 ]
+  then
+    mvn spring-boot:run
+  else
+    mvn spring-boot:run \
+    -Dspring-boot.run.arguments=--logging.level.se.kth.iv1201.recruitmentapplicationgroup5=$1    
+fi 

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/AccountController.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/AccountController.java
@@ -7,7 +7,6 @@ import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
@@ -1,8 +1,5 @@
 package se.kth.iv1201.recruitmentapplicationgroup5.controller;
 
-import java.io.IOException;
-import java.util.ArrayList;
-
 import javax.validation.ConstraintViolationException;
 
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
@@ -1,5 +1,7 @@
 package se.kth.iv1201.recruitmentapplicationgroup5.controller;
 
+import java.util.Arrays;
+
 import javax.validation.ConstraintViolationException;
 
 import org.springframework.http.HttpStatus;
@@ -67,7 +69,7 @@ public class ApiExceptionHandler {
 	
 	private ResponseEntity<Object> handleInternalError(Exception e, WebRequest req) {
 		log.debug(e.getMessage());
-		log.debug(e.getStackTrace().toString());
+		log.debug(Arrays.toString(e.getStackTrace()).replaceAll(",", "\n"));
 						
 		var status = HttpStatus.INTERNAL_SERVER_ERROR;
 		String url = extractUrl(req);

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
@@ -22,8 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 @ControllerAdvice
 public class ApiExceptionHandler {
 	
-	//Logger here as a private field
-	
 	@ExceptionHandler(value = MethodArgumentNotValidException.class)
 	public ResponseEntity<Object> handleValidationException(
 			MethodArgumentNotValidException e, 
@@ -68,9 +66,8 @@ public class ApiExceptionHandler {
 	}
 	
 	private ResponseEntity<Object> handleInternalError(Exception e, WebRequest req) {
-		//Log error here instead of System.out
-		System.out.println(e);
-		System.out.println(req);
+		log.debug(e.getMessage());
+		log.debug(e.getStackTrace().toString());
 						
 		var status = HttpStatus.INTERNAL_SERVER_ERROR;
 		String url = extractUrl(req);

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/ApiExceptionHandler.java
@@ -12,10 +12,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Class for encapsulating non default exception handling in one place.
  *
  */
+@Slf4j
 @ControllerAdvice
 public class ApiExceptionHandler {
 	
@@ -26,6 +29,7 @@ public class ApiExceptionHandler {
 			MethodArgumentNotValidException e, 
 			WebRequest req)
 	{
+		log.debug(e.getMessage());
 		var status = HttpStatus.BAD_REQUEST;
 		String url = extractUrl(req);
 		String errorMsg = generateErrMsg(e);
@@ -39,6 +43,7 @@ public class ApiExceptionHandler {
 			HttpMessageNotReadableException e, 
 			WebRequest req) 
 	{
+		log.debug(e.getMessage());
 		var status = HttpStatus.BAD_REQUEST;
 		String url = extractUrl(req);
 		var errorMsg = "Request body invalid JSON";
@@ -52,11 +57,13 @@ public class ApiExceptionHandler {
 			ConstraintViolationException e,
 			WebRequest req)
 	{
+		log.debug(e.getMessage());
 		return handleInternalError(e, req);
 	}
 	
 	@ExceptionHandler(value = Exception.class)
 	public ResponseEntity<Object> handleAllExceptions(Exception e, WebRequest req) {
+		log.debug(e.getMessage());
 		return handleInternalError(e, req);
 	}
 	

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -5,3 +5,6 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.h2.console.enabled=true
+
+# Sentry logging
+sentry.dsn=${SENTRY_DSN:}


### PR DESCRIPTION
Logging proof of concept.

Error logs are sent to Sentry as long as the environment variable SENTRY_DSN is set, otherwise not. This solves the problem of not sending lots of development logs to the cloud.

When running the application locally, logs at level INFO or higher (WARN, ERROR) are printed to STDOUT. If we want to set a lower level we can use a little script (run.sh) that is provided with this PR. Instructions on how to run the script is provided inside it.

closes #31 