### PR TITLE
Return 409 response when trying to register existing username

### DIFF
--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/AccountController.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/controller/AccountController.java
@@ -1,10 +1,12 @@
 package se.kth.iv1201.recruitmentapplicationgroup5.controller;
 
 import java.net.URI;
+import java.util.List;
 
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,7 +37,11 @@ public class AccountController {
 	 * @param registrationDetails - registration details for a new account
 	 */
 	@PostMapping("/accounts")
-	public ResponseEntity<AccountDTO> newAccount(@Valid @RequestBody RegistrationDetails registrationDetails) {
+	public ResponseEntity<?> newAccount(@Valid @RequestBody RegistrationDetails registrationDetails) {
+		List<AccountDTO> existingAccount = service.findAccount(registrationDetails.getUsername());
+		if (existingAccount.size() > 0) {
+			return new ResponseEntity<>(null, HttpStatus.CONFLICT);
+		}
 		AccountDTO createdAccount = service.addAccount(registrationDetails);
 		URI uri = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}").buildAndExpand(createdAccount.getId())
 				.toUri();

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/integration/AccountRepository.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/integration/AccountRepository.java
@@ -13,6 +13,15 @@ import se.kth.iv1201.recruitmentapplicationgroup5.model.Account;
  */
 public interface AccountRepository extends CrudRepository<Account, Integer>{
 
+	/**
+	 * Search for accounts by username.
+	 * 
+	 * Returns a list of {@link se.kth.iv1201.recruitmentapplicationgroup5.model.Account}
+	 * matching given username string given as parameter.
+	 *
+	 * @param username - username to search for
+	 * @return - list of Accounts matching username
+	 */
 	List<Account> findByUsername(String username);
 
 }

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/integration/AccountRepository.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/integration/AccountRepository.java
@@ -1,5 +1,7 @@
 package se.kth.iv1201.recruitmentapplicationgroup5.integration;
 
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 
 import se.kth.iv1201.recruitmentapplicationgroup5.model.Account;
@@ -7,9 +9,10 @@ import se.kth.iv1201.recruitmentapplicationgroup5.model.Account;
 /**
  * Interface containing database connection methods for
  *  {@link se.kth.iv1201.recruitmentapplicationgroup5.model.Account}.
- * @author Richard
  *
  */
 public interface AccountRepository extends CrudRepository<Account, Integer>{
+
+	List<Account> findByUsername(String username);
 
 }

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/service/AccountService.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/service/AccountService.java
@@ -1,5 +1,8 @@
 package se.kth.iv1201.recruitmentapplicationgroup5.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +44,11 @@ public class AccountService {
 		newAccount = repository.save(newAccount);
 		AccountDTO newAccountDTO = accountToDTO(newAccount);
 		return newAccountDTO;
+	}
+
+	public List<AccountDTO> findAccount(String username) {
+		List<Account> account = repository.findByUsername(username);
+		return account.stream().map(acc -> this.accountToDTO(acc)).collect(Collectors.toList());
 	}
 
 	private Account registrationToAccount(final RegistrationDetails details) {

--- a/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/service/AccountService.java
+++ b/backend/src/main/java/se/kth/iv1201/recruitmentapplicationgroup5/service/AccountService.java
@@ -38,6 +38,7 @@ public class AccountService {
 	 * Account created from the information in {@link RegistrationDetails}.
 	 *
 	 * @param registrationDetails - details for new account
+	 * @return - created account as DTO
 	 */
 	public AccountDTO addAccount(@Valid RegistrationDetails registrationDetails) {
 		Account newAccount = registrationToAccount(registrationDetails);
@@ -46,6 +47,15 @@ public class AccountService {
 		return newAccountDTO;
 	}
 
+	/**
+	 * List accounts with matching username.
+	 * 
+	 * Returns a list of {@link se.kth.iv1201.recruitmentapplicationgroup5.model.dto.AccountDTO}
+	 * matching username given as parameter.
+	 *
+	 * @param username - username to search for
+	 * @return - list of matching accounts as DTOs
+	 */
 	public List<AccountDTO> findAccount(String username) {
 		List<Account> account = repository.findByUsername(username);
 		return account.stream().map(acc -> this.accountToDTO(acc)).collect(Collectors.toList());

--- a/frontend/src/containers/RegistrationContainer/RegistrationContainer.js
+++ b/frontend/src/containers/RegistrationContainer/RegistrationContainer.js
@@ -49,16 +49,14 @@ function RegistrationContainer() {
 
 		postToAPI(endpoints.ACCOUNTS, formattedRegistrationDetails)
 			.then((response) => {
-				console.log(response)
 				event.target.reset();
 				showAlert(alertTypes.SUCCESS, "Registration was successful")
 			})
 			.catch((error) =>{
 				if(error.message === "Conflict") {
 					document.getElementsByName('username')[0].value = "";
-					showAlert(alertTypes.ERROR, "Existing username")
+					showAlert(alertTypes.ERROR, "User already exists")
 				} else {
-					console.log(error)
 					showAlert(alertTypes.ERROR, "Something went wrong")
 				}
 			});

--- a/frontend/src/containers/RegistrationContainer/RegistrationContainer.js
+++ b/frontend/src/containers/RegistrationContainer/RegistrationContainer.js
@@ -45,17 +45,23 @@ function RegistrationContainer() {
 
 	function handleFormSubmit(registrationDetails, event) {
 		event.preventDefault();
-		event.target.reset();
-
 		const formattedRegistrationDetails = formatDetails(registrationDetails);
 
 		postToAPI(endpoints.ACCOUNTS, formattedRegistrationDetails)
-			.then((response) =>
+			.then((response) => {
+				console.log(response)
+				event.target.reset();
 				showAlert(alertTypes.SUCCESS, "Registration was successful")
-			)
-			.catch((error) =>
-				showAlert(alertTypes.ERROR, "Something went wrong")
-			);
+			})
+			.catch((error) =>{
+				if(error.message === "Conflict") {
+					document.getElementsByName('username')[0].value = "";
+					showAlert(alertTypes.ERROR, "Existing username")
+				} else {
+					console.log(error)
+					showAlert(alertTypes.ERROR, "Something went wrong")
+				}
+			});
 	}
 
 	return (

--- a/frontend/src/util/network.js
+++ b/frontend/src/util/network.js
@@ -1,5 +1,7 @@
 function handleResponse(response) {
-	if (![200, 201].includes(response.status)) {
+	if (response.status === 409) {
+		throw new Error("Conflict");
+	} else if (![200, 201].includes(response.status)) {
 		throw new Error("Something went wrong");
 	} else {
 		return response.json();


### PR DESCRIPTION
The PR solves the issue of missing information when a user tries to register an existing account.

The frontend code is somewhat crude. It just checks for 409 and in the registration page assumes this is a username conflict. This results in a message "Username exists" and the username field is emptied.

The registration fields are now only reset'ed if there is a succes.

Also cleaned up some test code and some javadocs.

This code does not solve the possibility to have duplicates in the database. It only stops new registrations to enter the database if one exist